### PR TITLE
Add individual permissions

### DIFF
--- a/src/main/java/com/moulberry/axiom/AxiomPaper.java
+++ b/src/main/java/com/moulberry/axiom/AxiomPaper.java
@@ -301,11 +301,24 @@ public class AxiomPaper extends JavaPlugin implements Listener {
     }
 
     public boolean hasAxiomPermission(Player player) {
-        return player.hasPermission("axiom.*") || player.isOp();
+        return hasAxiomPermission(player, null);
+    }
+
+    public boolean hasAxiomPermission(Player player, String permission) {
+        if (player.hasPermission("axiom.*") || player.isOp()) {
+            return true;
+        } else if (permission != null && !player.hasPermission(permission)) {
+            return false;
+        }
+        return player.hasPermission("axiom.use");
     }
 
     public boolean canUseAxiom(Player player) {
-        return hasAxiomPermission(player) && activeAxiomPlayers.contains(player.getUniqueId());
+        return canUseAxiom(player, null);
+    }
+
+    public boolean canUseAxiom(Player player, String permission) {
+        return activeAxiomPlayers.contains(player.getUniqueId()) && hasAxiomPermission(player, permission);
     }
 
     public @Nullable RateLimiter getBlockBufferRateLimiter(UUID uuid) {

--- a/src/main/java/com/moulberry/axiom/packet/BlueprintRequestPacketListener.java
+++ b/src/main/java/com/moulberry/axiom/packet/BlueprintRequestPacketListener.java
@@ -36,7 +36,7 @@ public class BlueprintRequestPacketListener implements PluginMessageListener {
     }
 
     private void process(Player player, byte[] message) {
-        if (!this.plugin.canUseAxiom(player)) {
+        if (!this.plugin.canUseAxiom(player, "axiom.blueprint.request")) {
             return;
         }
 

--- a/src/main/java/com/moulberry/axiom/packet/DeleteEntityPacketListener.java
+++ b/src/main/java/com/moulberry/axiom/packet/DeleteEntityPacketListener.java
@@ -35,11 +35,7 @@ public class DeleteEntityPacketListener implements PluginMessageListener {
     }
 
     private void process(Player player, byte[] message) {
-        if (!this.plugin.canUseAxiom(player)) {
-            return;
-        }
-
-        if (!player.hasPermission("axiom.entity.*") && !player.hasPermission("axiom.entity.delete")) {
+        if (!this.plugin.canUseAxiom(player, "axiom.entity.delete")) {
             return;
         }
 

--- a/src/main/java/com/moulberry/axiom/packet/ManipulateEntityPacketListener.java
+++ b/src/main/java/com/moulberry/axiom/packet/ManipulateEntityPacketListener.java
@@ -90,11 +90,7 @@ public class ManipulateEntityPacketListener implements PluginMessageListener {
     }
 
     private void process(Player player, byte[] message) {
-        if (!this.plugin.canUseAxiom(player)) {
-            return;
-        }
-
-        if (!player.hasPermission("axiom.entity.*") && !player.hasPermission("axiom.entity.manipulate")) {
+        if (!this.plugin.canUseAxiom(player, "axiom.entity.manipulate")) {
             return;
         }
 

--- a/src/main/java/com/moulberry/axiom/packet/MarkerNbtRequestPacketListener.java
+++ b/src/main/java/com/moulberry/axiom/packet/MarkerNbtRequestPacketListener.java
@@ -33,11 +33,7 @@ public class MarkerNbtRequestPacketListener implements PluginMessageListener {
     }
 
     private void process(Player player, byte[] message) {
-        if (!this.plugin.canUseAxiom(player)) {
-            return;
-        }
-
-        if (!player.hasPermission("axiom.entity.*") && !player.hasPermission("axiom.entity.manipulate")) {
+        if (!this.plugin.canUseAxiom(player, "axiom.entity.manipulate")) {
             return;
         }
 

--- a/src/main/java/com/moulberry/axiom/packet/RequestChunkDataPacketListener.java
+++ b/src/main/java/com/moulberry/axiom/packet/RequestChunkDataPacketListener.java
@@ -56,7 +56,7 @@ public class RequestChunkDataPacketListener implements PluginMessageListener {
         FriendlyByteBuf friendlyByteBuf = new FriendlyByteBuf(Unpooled.wrappedBuffer(message));
         long id = friendlyByteBuf.readLong();
 
-        if (!this.plugin.canUseAxiom(bukkitPlayer) || this.plugin.isMismatchedDataVersion(bukkitPlayer.getUniqueId())) {
+        if (!this.plugin.canUseAxiom(bukkitPlayer, "axiom.chunk.request") || this.plugin.isMismatchedDataVersion(bukkitPlayer.getUniqueId())) {
             // We always send an 'empty' response in order to make the client happy
             sendEmptyResponse(player, id);
             return;

--- a/src/main/java/com/moulberry/axiom/packet/SetBlockBufferPacketListener.java
+++ b/src/main/java/com/moulberry/axiom/packet/SetBlockBufferPacketListener.java
@@ -124,7 +124,7 @@ public class SetBlockBufferPacketListener {
                 ServerLevel world = player.serverLevel();
                 if (!world.dimension().equals(worldKey)) return;
 
-                if (!this.plugin.canUseAxiom(player.getBukkitEntity())) {
+                if (!this.plugin.canUseAxiom(player.getBukkitEntity(), "axiom.build.section")) {
                     return;
                 }
 
@@ -316,7 +316,7 @@ public class SetBlockBufferPacketListener {
                 ServerLevel world = player.serverLevel();
                 if (!world.dimension().equals(worldKey)) return;
 
-                if (!this.plugin.canUseAxiom(player.getBukkitEntity())) {
+                if (!this.plugin.canUseAxiom(player.getBukkitEntity(), "axiom.build.section")) {
                     return;
                 }
 

--- a/src/main/java/com/moulberry/axiom/packet/SetBlockPacketListener.java
+++ b/src/main/java/com/moulberry/axiom/packet/SetBlockPacketListener.java
@@ -78,7 +78,7 @@ public class SetBlockPacketListener implements PluginMessageListener {
     }
 
     private void process(Player bukkitPlayer, byte[] message) {
-        if (!this.plugin.canUseAxiom(bukkitPlayer)) {
+        if (!this.plugin.canUseAxiom(bukkitPlayer, "axiom.build.place")) {
             return;
         }
 

--- a/src/main/java/com/moulberry/axiom/packet/SetEditorViewsPacketListener.java
+++ b/src/main/java/com/moulberry/axiom/packet/SetEditorViewsPacketListener.java
@@ -35,7 +35,7 @@ public class SetEditorViewsPacketListener implements PluginMessageListener {
     }
 
     private void process(Player player, byte[] message) {
-        if (!this.plugin.canUseAxiom(player)) {
+        if (!this.plugin.canUseAxiom(player, "axiom.editor.views")) {
             return;
         }
 

--- a/src/main/java/com/moulberry/axiom/packet/SetFlySpeedPacketListener.java
+++ b/src/main/java/com/moulberry/axiom/packet/SetFlySpeedPacketListener.java
@@ -28,7 +28,7 @@ public class SetFlySpeedPacketListener implements PluginMessageListener {
     }
 
     private void process(Player player, byte[] message) {
-        if (!this.plugin.canUseAxiom(player)) {
+        if (!this.plugin.canUseAxiom(player, "axiom.player.speed")) {
             return;
         }
 

--- a/src/main/java/com/moulberry/axiom/packet/SetGamemodePacketListener.java
+++ b/src/main/java/com/moulberry/axiom/packet/SetGamemodePacketListener.java
@@ -30,7 +30,7 @@ public class SetGamemodePacketListener implements PluginMessageListener {
     }
 
     private void process(Player player, byte[] message) {
-        if (!this.plugin.canUseAxiom(player)) {
+        if (!this.plugin.canUseAxiom(player, "axiom.player.gamemode")) {
             return;
         }
 

--- a/src/main/java/com/moulberry/axiom/packet/SetHotbarSlotPacketListener.java
+++ b/src/main/java/com/moulberry/axiom/packet/SetHotbarSlotPacketListener.java
@@ -35,7 +35,7 @@ public class SetHotbarSlotPacketListener implements PluginMessageListener {
     }
 
     private void process(Player player, byte[] message) {
-        if (!this.plugin.canUseAxiom(player) || this.plugin.isMismatchedDataVersion(player.getUniqueId())) {
+        if (!this.plugin.canUseAxiom(player, "axiom.player.hotbar") || this.plugin.isMismatchedDataVersion(player.getUniqueId())) {
             return;
         }
 

--- a/src/main/java/com/moulberry/axiom/packet/SetTimePacketListener.java
+++ b/src/main/java/com/moulberry/axiom/packet/SetTimePacketListener.java
@@ -34,7 +34,7 @@ public class SetTimePacketListener implements PluginMessageListener {
     }
 
     private void process(Player player, byte[] message) {
-        if (!this.plugin.canUseAxiom(player)) {
+        if (!this.plugin.canUseAxiom(player, "axiom.world.time")) {
             return;
         }
 

--- a/src/main/java/com/moulberry/axiom/packet/SetWorldPropertyListener.java
+++ b/src/main/java/com/moulberry/axiom/packet/SetWorldPropertyListener.java
@@ -29,7 +29,7 @@ public class SetWorldPropertyListener implements PluginMessageListener {
     }
 
     private void process(Player player, byte[] message) {
-        if (!this.plugin.canUseAxiom(player)) {
+        if (!this.plugin.canUseAxiom(player, "axiom.world.property")) {
             return;
         }
 

--- a/src/main/java/com/moulberry/axiom/packet/SpawnEntityPacketListener.java
+++ b/src/main/java/com/moulberry/axiom/packet/SpawnEntityPacketListener.java
@@ -55,11 +55,7 @@ public class SpawnEntityPacketListener implements PluginMessageListener {
     }
 
     private void process(Player player, byte[] message) {
-        if (!this.plugin.canUseAxiom(player)) {
-            return;
-        }
-
-        if (!player.hasPermission("axiom.entity.*") && !player.hasPermission("axiom.entity.spawn")) {
+        if (!this.plugin.canUseAxiom(player, "axiom.entity.spawn")) {
             return;
         }
 

--- a/src/main/java/com/moulberry/axiom/packet/SwitchActiveHotbarPacketListener.java
+++ b/src/main/java/com/moulberry/axiom/packet/SwitchActiveHotbarPacketListener.java
@@ -36,7 +36,7 @@ public class SwitchActiveHotbarPacketListener implements PluginMessageListener {
     }
 
     private void process(Player player, byte[] message) {
-        if (!this.plugin.canUseAxiom(player) || this.plugin.isMismatchedDataVersion(player.getUniqueId())) {
+        if (!this.plugin.canUseAxiom(player, "axiom.player.hotbar") || this.plugin.isMismatchedDataVersion(player.getUniqueId())) {
             return;
         }
 

--- a/src/main/java/com/moulberry/axiom/packet/TeleportPacketListener.java
+++ b/src/main/java/com/moulberry/axiom/packet/TeleportPacketListener.java
@@ -33,7 +33,7 @@ public class TeleportPacketListener implements PluginMessageListener {
     }
 
     private void process(Player player, byte[] message) {
-        if (!this.plugin.canUseAxiom(player)) {
+        if (!this.plugin.canUseAxiom(player, "axiom.world.teleport")) {
             return;
         }
 

--- a/src/main/java/com/moulberry/axiom/packet/UploadBlueprintPacketListener.java
+++ b/src/main/java/com/moulberry/axiom/packet/UploadBlueprintPacketListener.java
@@ -24,7 +24,7 @@ public class UploadBlueprintPacketListener  {
     }
 
     public void onReceive(ServerPlayer serverPlayer, FriendlyByteBuf friendlyByteBuf) {
-        if (!this.plugin.canUseAxiom(serverPlayer.getBukkitEntity())) {
+        if (!this.plugin.canUseAxiom(serverPlayer.getBukkitEntity(), "axiom.blueprint.upload")) {
             return;
         }
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -5,9 +5,16 @@ description: $description
 authors:
   - Moulberry
 api-version: "$apiVersion"
+softdepend:
+  - ViaVersion
+  - WorldGuard
+  - PlotSquared
 permissions:
   axiom.*:
     description: Allows use of all default Axiom features
+    default: op
+  axiom.use:
+    description: Allows basic use of axiom
     default: op
   axiom.debug:
     description: Allows use of the /axiompaperdebug command
@@ -15,12 +22,47 @@ permissions:
   axiom.entity.*:
     description: Allows use of all entity-related features (spawning, manipulating, deleting)
     default: op
-  axiom.entity.spawn:
-    description: Allows entity spawning
-  axiom.entity.manipulate:
-    description: Allows entity manipulation
-  axiom.entity.delete:
-    description: Allows entity deletion
+    children:
+      axiom.entity.spawn: true
+      axiom.entity.manipulate: true
+      axiom.entity.delete: true
+  axiom.blueprint.*:
+    description: Allows use of all blueprint-related features
+    default: op
+    children:
+      axiom.blueprint.upload: true
+      axiom.blueprint.request: true
+      axiom.blueprint.manifest: true
+  axiom.chunk.*:
+    description: Allows use of all chunk-related features
+    default: op
+    children:
+      axiom.chunk.request: true
+  axiom.build.*:
+    description: Allows use of all build-related features
+    default: op
+    children:
+      axiom.build.place: true
+      axiom.build.section: true
+  axiom.editor.*:
+    description: Allows use of all editor-related features
+    default: op
+    children:
+      axiom.editor.views: true
+  axiom.player.*:
+    description: Allows use of all player-related features
+    default: op
+    children:
+      axiom.player.speed: true
+      axiom.player.gamemode: true
+      axiom.player.hotbar: true
+  axiom.world.*:
+    description: Allows use of all world-related features
+    default: op
+    children:
+      axiom.world.time: true
+      axiom.world.property: true
+      axiom.world.teleport: true
 
   axiom.allow_copying_other_plots:
     description: This permission allows users to copy other user's plots


### PR DESCRIPTION
From plugin.yml file:

```yaml
axiom.*:
  description: Allows use of all default Axiom features
  default: op
axiom.use:
  description: Allows basic use of axiom
  default: op
axiom.debug:
  description: Allows use of the /axiompaperdebug command
  default: op
axiom.entity.*:
  description: Allows use of all entity-related features (spawning, manipulating, deleting)
  default: op
  children:
    axiom.entity.spawn: true
    axiom.entity.manipulate: true
    axiom.entity.delete: true
axiom.blueprint.*:
  description: Allows use of all blueprint-related features
  default: op
  children:
    axiom.blueprint.upload: true
    axiom.blueprint.request: true
    axiom.blueprint.manifest: true
axiom.chunk.*:
  description: Allows use of all chunk-related features
  default: op
  children:
    axiom.chunk.request: true
axiom.build.*:
  description: Allows use of all build-related features
  default: op
  children:
    axiom.build.place: true
    axiom.build.section: true
axiom.editor.*:
  description: Allows use of all editor-related features
  default: op
  children:
    axiom.editor.views: true
axiom.player.*:
  description: Allows use of all player-related features
  default: op
  children:
    axiom.player.speed: true
    axiom.player.gamemode: true
    axiom.player.hotbar: true
axiom.world.*:
  description: Allows use of all world-related features
  default: op
  children:
    axiom.world.time: true
    axiom.world.property: true
    axiom.world.teleport: true
```