### PR TITLE
Correctly decode/encode opacity in ImageAnnotationData

### DIFF
--- a/src/main/java/com/moulberry/axiom/annotations/data/ImageAnnotationData.java
+++ b/src/main/java/com/moulberry/axiom/annotations/data/ImageAnnotationData.java
@@ -5,7 +5,7 @@ import net.minecraft.network.FriendlyByteBuf;
 import org.joml.Quaternionf;
 import org.joml.Vector3f;
 
-public record ImageAnnotationData(String imageUrl, Vector3f position, Quaternionf rotation, Direction direction, float fallbackYaw, float width, int billboardMode) implements AnnotationData {
+public record ImageAnnotationData(String imageUrl, Vector3f position, Quaternionf rotation, Direction direction, float fallbackYaw, float width, float opacity, int billboardMode) implements AnnotationData {
 
     @Override
     public void setPosition(Vector3f position) {
@@ -31,6 +31,7 @@ public record ImageAnnotationData(String imageUrl, Vector3f position, Quaternion
         friendlyByteBuf.writeByte(this.direction.get3DDataValue());
         friendlyByteBuf.writeFloat(this.fallbackYaw);
         friendlyByteBuf.writeFloat(this.width);
+        friendlyByteBuf.writeFloat(this.opacity);
         friendlyByteBuf.writeByte(this.billboardMode);
     }
 
@@ -46,8 +47,9 @@ public record ImageAnnotationData(String imageUrl, Vector3f position, Quaternion
         Direction direction = Direction.from3DDataValue(friendlyByteBuf.readByte());
         float fallbackYaw = friendlyByteBuf.readFloat();
         float width = friendlyByteBuf.readFloat();
+        float opacity = friendlyByteBuf.readFloat();
         int billboardMode = friendlyByteBuf.readByte();
-        return new ImageAnnotationData(imageUrl, new Vector3f(x, y, z), new Quaternionf(rotX, rotY, rotZ, rotW), direction, fallbackYaw, width, billboardMode);
+        return new ImageAnnotationData(imageUrl, new Vector3f(x, y, z), new Quaternionf(rotX, rotY, rotZ, rotW), direction, fallbackYaw, width, opacity, billboardMode);
     }
 
 }


### PR DESCRIPTION
Axiom 4.0.0 was causing server players to crash with the following message when placing an image annotation in to the world: 

```
Encountered exception while handling in channel with name "axiom:annotation_update"
java.lang.IndexOutOfBoundsException: readerIndex(58) + length(4) exceeds writerIndex(59): UnpooledByteBufAllocator$InstrumentedUnpooledUnsafeHeapByteBuf(ridx: 58, widx: 59, cap: 59)
```

This was caused by an unbalanced data write/read between client and server. This has been fixed by correctly reading/writing the opacity data from the Axiom client, which was missing from the server implementation.