### PR TITLE
Cancellable block events

### DIFF
--- a/src/main/java/com/moulberry/axiom/event/AxiomBlockBreakEvent.java
+++ b/src/main/java/com/moulberry/axiom/event/AxiomBlockBreakEvent.java
@@ -1,0 +1,48 @@
+package com.moulberry.axiom.event;
+
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+public class AxiomBlockBreakEvent extends Event implements Cancellable {
+
+    private static final HandlerList HANDLERS = new HandlerList();
+    private boolean isCancelled;
+
+    private final Player player;
+    private final Block block;
+
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+
+    public AxiomBlockBreakEvent(Player player, Block block){
+        this.player = player;
+        this.block = block;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return this.isCancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean isCancelled) {
+        this.isCancelled = isCancelled;
+    }
+
+    public Player getPlayer() {
+        return player;
+    }
+
+    public Block getBlock() {
+        return block;
+    }
+}

--- a/src/main/java/com/moulberry/axiom/event/AxiomBlockPlaceEvent.java
+++ b/src/main/java/com/moulberry/axiom/event/AxiomBlockPlaceEvent.java
@@ -1,0 +1,48 @@
+package com.moulberry.axiom.event;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+public class AxiomBlockPlaceEvent extends Event implements Cancellable {
+
+    private static final HandlerList HANDLERS = new HandlerList();
+    private boolean isCancelled;
+
+    private final Player player;
+    private final Location loc;
+
+    public AxiomBlockPlaceEvent(Player player, Location loc) {
+        this.player = player;
+        this.loc = loc;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return this.isCancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean isCancelled) {
+        this.isCancelled = isCancelled;
+    }
+
+    public Player getPlayer() {
+        return player;
+    }
+
+    public Location getLocation() {
+        return loc;
+    }
+}

--- a/src/main/java/com/moulberry/axiom/event/AxiomModifyRegionEvent.java
+++ b/src/main/java/com/moulberry/axiom/event/AxiomModifyRegionEvent.java
@@ -1,0 +1,84 @@
+package com.moulberry.axiom.event;
+
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+public class AxiomModifyRegionEvent extends Event implements Cancellable {
+    
+    private static final HandlerList HANDLERS = new HandlerList();
+    private boolean isCancelled;
+
+    private final Player player;
+    private final World world;
+    private final long minX;
+    private final long minY;
+    private final long minZ;
+    private final long maxX;
+    private final long maxY;
+    private final long maxZ;
+
+    public AxiomModifyRegionEvent(Player player, World world, long minX, long minY, long minZ, long maxX, long maxY, long maxZ) {
+        this.player = player;
+        this.world = world;
+        this.minX = minX;
+        this.minY = minY;
+        this.minZ = minZ;
+        this.maxX = maxX;
+        this.maxY = maxY;
+        this.maxZ = maxZ;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return this.isCancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean isCancelled) {
+        this.isCancelled = isCancelled;
+    }
+
+    public Player getPlayer() {
+        return player;
+    }
+
+    public World getWorld() {
+        return world;
+    }
+
+    public long getMinX() {
+        return minX;
+    }
+
+    public long getMinY() {
+        return minY;
+    }
+
+    public long getMinZ() {
+        return minZ;
+    }
+
+    public long getMaxX() {
+        return maxX;
+    }
+
+    public long getMaxY() {
+        return maxY;
+    }
+
+    public long getMaxZ() {
+        return maxZ;
+    }
+}

--- a/src/main/java/com/moulberry/axiom/integration/Integration.java
+++ b/src/main/java/com/moulberry/axiom/integration/Integration.java
@@ -1,7 +1,11 @@
 package com.moulberry.axiom.integration;
 
+import com.moulberry.axiom.event.AxiomBlockBreakEvent;
+import com.moulberry.axiom.event.AxiomBlockPlaceEvent;
+import com.moulberry.axiom.event.AxiomModifyRegionEvent;
 import com.moulberry.axiom.integration.plotsquared.PlotSquaredIntegration;
 import com.moulberry.axiom.integration.worldguard.WorldGuardIntegration;
+import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
@@ -11,14 +15,40 @@ public class Integration {
     // todo: test if all this is working for both plotsqured, worldguard, plotsquared+worldguard
 
     public static boolean canBreakBlock(Player player, Block block) {
+
+        // Allow other permission plugins to cancel the block break event
+        final var event = new AxiomBlockBreakEvent(player, block);
+        Bukkit.getPluginManager().callEvent(event);
+        if(event.isCancelled()) {
+            return false;
+        }
+
         return PlotSquaredIntegration.canBreakBlock(player, block) && WorldGuardIntegration.canBreakBlock(player, block.getLocation());
     }
 
     public static boolean canPlaceBlock(Player player, org.bukkit.Location loc) {
+
+        // Allow other permission plugins to cancel the block place event
+        final var event = new AxiomBlockPlaceEvent(player, loc);
+        Bukkit.getPluginManager().callEvent(event);
+        if(event.isCancelled()) {
+            return false;
+        }
+
         return PlotSquaredIntegration.canPlaceBlock(player, loc) && WorldGuardIntegration.canPlaceBlock(player, loc);
     }
 
     public static SectionPermissionChecker checkSection(Player player, World world, int cx, int cy, int cz) {
+
+        // Allow other permission plugins to cancel the modify region event
+        final var event = new AxiomModifyRegionEvent(player, world, 
+            cx * 16, cy * 16, cz * 16, 
+            cx * 16 + 15, cy * 16 + 15, cz * 16 + 15);
+        Bukkit.getPluginManager().callEvent(event);
+        if(event.isCancelled()) {
+            return SectionPermissionChecker.NONE_ALLOWED;
+        }
+
         SectionPermissionChecker plotSquared = PlotSquaredIntegration.checkSection(player, world, cx, cy, cz);
         SectionPermissionChecker worldGuard = WorldGuardIntegration.checkSection(player, world, cx, cy, cz);
 


### PR DESCRIPTION
Allow other plugins to cancel the BreakBlock, PlaceBlock, and ModifyRegion events.

Handing over the responsibility to the permissions plugins allow for a less granular, more efficient, region or block check. A valid use case for limiting Axiom use per user.

This PR could be a stepping-stone to handing over permission responsibility like WourldGuard, etc.