### PR TITLE
Update cloud-paper dependency

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # Dependencies
 bom-newest = "1.37"
-cloud-paper = "2.0.0-20240516.054251-69"
+cloud-paper = "2.0.0-beta.11"
 coreprotect = "22.4"
 paper = "1.21.6-R0.1-SNAPSHOT"
 plotsquared = "7.3.8"


### PR DESCRIPTION
This PR updates the `cloud-paper` dependency to `2.0.0-beta.11`.

This update is needed in order to remove the deprecated `PlayerLoginEvent` from this dependency, which causes:
1. This warning message in the console: `[HorriblePlayerLoginEventHack] You have plugins listening to the PlayerLoginEvent, this will cause re-configuration APIs to be unavailable: [AxiomPaper, ...]`
2. The configuration API to be unavailable as stated above. When other plugins now try to use `PlayerGameConnection#reenterConfiguration()`, it will not work and an additional warning message will appear:
```
============================================================
WARNING: SomeRandomPlugin Attempted to use PlayerGameConnection#reenterConfiguration()

This method currently requires that all plugins installed on the server
are not listening to the PlayerLoginEvent.

Please look in your logs for the Plugins listening to this event.
============================================================
```

With this update of the `cloud-paper` dependency this warning will no longer appear because of the AxiomPaper plugin, while all of its functionality remains identical.