### PR TITLE
feat: Add Folia Support

### DIFF
--- a/src/main/java/com/moulberry/axiom/AxiomPaper.java
+++ b/src/main/java/com/moulberry/axiom/AxiomPaper.java
@@ -240,7 +240,7 @@ public class AxiomPaper extends JavaPlugin implements Listener {
         } catch (IOException ignored) {}
         ServerHeightmaps.load(heightmapsPath);
 
-        Bukkit.getScheduler().scheduleSyncRepeatingTask(this, this::tick, 1, 1);
+        Bukkit.getGlobalRegionScheduler().runAtFixedRate(this, (task) -> this.tick(), 1L, 1L);
 
         this.sendMarkers = this.configuration.getBoolean("send-markers");
         this.maxChunkRelightsPerTick = this.configuration.getInt("max-chunk-relights-per-tick");

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -6,6 +6,7 @@ authors:
   - Moulberry
 api-version: "$apiVersion"
 softdepend: ["CoreProtect", "ViaVersion", "WorldGuard", "PlotSquared"]
+folia-supported: true
 permissions:
   axiom.all:
     description: Allows use of ALL Axiom features. Same as /op. This permission bypasses all other permissions.


### PR DESCRIPTION
This pull request introduces compatibility for the Folia server software by utilizing the modern Paper API.

### The Problem
The legacy Bukkit scheduler (`Bukkit.getScheduler()`) is not designed for Folia's multi-threaded environment and can cause server instability or errors. Without these changes, the plugin will not function correctly on a Folia server.

### The Solution
This PR implements the necessary changes to ensure compatibility with both modern Paper and Folia servers:

-   **`plugin.yml`**: Added the `folia-supported: true` flag, which is required for Folia to recognize and load the plugin.
-   **`AxiomPaper.java`**: Replaced the legacy `scheduleSyncRepeatingTask` with `Bukkit.getGlobalRegionScheduler().runAtFixedRate()`. This method is part of the **Paper API** and provides forward compatibility.
    -   On a **Folia** server, it uses the appropriate region-based thread.
    -   On a standard **Paper** server, it safely falls back to the main server thread.

This ensures the plugin's main task runs in a stable, thread-safe manner across different server types without requiring separate plugin versions.

I have tested this build on a Folia and a Paper server and can confirm it works as expected.